### PR TITLE
Different stored and indexed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.umich.lib</groupId>
   <artifactId>library_identifier_solr_filters</artifactId>
-  <version>0.2</version>
+  <version>0.3</version>
 
   <build>
     <finalName>library_identifier_solr_filters-${project.version}-solr${solr.version}</finalName>

--- a/src/main/edu/umich/library/library_identifier/normalizers/LCCallNumberSimple.java
+++ b/src/main/edu/umich/library/library_identifier/normalizers/LCCallNumberSimple.java
@@ -3,6 +3,7 @@ package edu.umich.library.library_identifier.normalizers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -14,10 +15,10 @@ public class LCCallNumberSimple {
     public  String digits = "";
     public  String decimals = "";
     public  String rest = "";
-    public  Boolean isValid = false;
+    public  Boolean isValid;
 
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LCCallNumberSimple.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public static Pattern lc_start = Pattern.compile(
             "^\\s*(?<letters>\\p{L}{1,4})\\s*" + // 1-4 initial letters, plus optional whitespace
@@ -64,7 +65,7 @@ public class LCCallNumberSimple {
 
     public String collation_digits() {
         Integer digit_length = digits.length();
-        return digit_length.toString() + digits;
+        return digit_length + digits;
     }
 
     public String collation_decimals() {

--- a/src/main/edu/umich/library/library_identifier/schema/CallnumberSortableFieldType.java
+++ b/src/main/edu/umich/library/library_identifier/schema/CallnumberSortableFieldType.java
@@ -1,27 +1,14 @@
 package edu.umich.library.library_identifier.schema;
 
 import edu.umich.library.library_identifier.normalizers.LCCallNumberSimple;
-import org.apache.lucene.document.SortedDocValuesField;
-import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.search.SortField;
-import org.apache.lucene.util.BytesRef;
-import org.apache.solr.common.SolrException;
-import org.apache.solr.common.util.ByteArrayUtf8CharSequence;
-import org.apache.solr.response.TextResponseWriter;
-import org.apache.solr.schema.FieldType;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.schema.StrField;
-import org.apache.solr.uninverting.UninvertingReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 public class CallnumberSortableFieldType extends StrField {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -29,8 +16,7 @@ public class CallnumberSortableFieldType extends StrField {
   @Override
   public String toInternal(String val) {
     LCCallNumberSimple lccns = new LCCallNumberSimple(val);
-    String ckey = lccns.any_collation_key();
-    return ckey;
+    return lccns.any_collation_key();
   }
 
   @Override

--- a/src/main/edu/umich/library/library_identifier/schema/CallnumberSortableFieldType.java
+++ b/src/main/edu/umich/library/library_identifier/schema/CallnumberSortableFieldType.java
@@ -1,11 +1,27 @@
 package edu.umich.library.library_identifier.schema;
 
 import edu.umich.library.library_identifier.normalizers.LCCallNumberSimple;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.util.BytesRef;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.util.ByteArrayUtf8CharSequence;
+import org.apache.solr.response.TextResponseWriter;
+import org.apache.solr.schema.FieldType;
+import org.apache.solr.schema.SchemaField;
 import org.apache.solr.schema.StrField;
+import org.apache.solr.uninverting.UninvertingReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class CallnumberSortableFieldType extends StrField {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -13,6 +29,25 @@ public class CallnumberSortableFieldType extends StrField {
   @Override
   public String toInternal(String val) {
     LCCallNumberSimple lccns = new LCCallNumberSimple(val);
-    return lccns.any_collation_key();
+    String ckey = lccns.any_collation_key();
+    return ckey;
+  }
+
+  @Override
+  public IndexableField createField(SchemaField field, Object value) {
+    if (!field.indexed() && !field.stored()) {
+      if (log.isTraceEnabled())
+        log.trace("Ignoring unindexed/unstored field: {}", field);
+      return null;
+    }
+
+    String val = value.toString();
+    if (val==null) return null;
+    org.apache.lucene.document.FieldType newType = new org.apache.lucene.document.FieldType();
+    newType.setTokenized(true);
+    newType.setStored(field.stored());
+    newType.setIndexOptions(IndexOptions.DOCS);
+
+    return createField(field.getName(), val, newType);
   }
 }

--- a/src/main/edu/umich/library/lucene/analysis/LCCallNumberSimpleFilter.java
+++ b/src/main/edu/umich/library/lucene/analysis/LCCallNumberSimpleFilter.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import edu.umich.library.library_identifier.normalizers.LCCallNumberSimple;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 
 /**
  * A Solr filter that take an LC Call Number (/ shelf key) and
@@ -26,7 +27,7 @@ public final class LCCallNumberSimpleFilter extends TokenFilter {
    * Logger used to log info/warnings.
    */
   private static final Logger LOGGER = LoggerFactory
-      .getLogger(LCCallNumberSimpleFilter.class);
+      .getLogger(MethodHandles.lookup().lookupClass());
 
   /**
    * The filter term that is a result of the conversion.
@@ -39,7 +40,7 @@ public final class LCCallNumberSimpleFilter extends TokenFilter {
    * or return nothing (default)
    */
 
-  private Boolean passThroughInvalid = false;
+  private Boolean passThroughInvalid;
 
   /**
    * @param aStream A {@link TokenStream} that parses streams with
@@ -49,6 +50,11 @@ public final class LCCallNumberSimpleFilter extends TokenFilter {
     super(aStream);
     this.passThroughInvalid = passThroughInvalid;
   }
+
+  public LCCallNumberSimpleFilter(TokenStream aStream) {
+    this(aStream, false);
+  }
+
 
   /**
    * Increments and processes tokens in the ISO-639 code stream.

--- a/src/main/edu/umich/library/lucene/analysis/LCCallNumberSimpleFilterFactory.java
+++ b/src/main/edu/umich/library/lucene/analysis/LCCallNumberSimpleFilterFactory.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * </fieldType>
  */
 public class LCCallNumberSimpleFilterFactory extends TokenFilterFactory {
-  private Boolean passThroughInvalid = false;
+  private Boolean passThroughInvalid;
 
   public LCCallNumberSimpleFilterFactory(Map<String, String> args) {
     super(args);


### PR DESCRIPTION
Substantial renaming of packages, bump to version 0.3, `edu.umich.library.library_identifier.schema.CallnumberSortableFieldType` now has different stored/indexed values. Man, that took an embarrassingly long time to figure out.